### PR TITLE
ci: run mypy only on Python 3.13 leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,14 @@ jobs:
       - name: Lint
         run: uv run ruff check src tests
 
+      # mypy is configured for python_version = "3.13" (see [tool.mypy]) and
+      # type-checks against the numpy stubs installed in the active env. On the
+      # 3.10 matrix leg the resolved numpy (2.2.6) ships ndarray TypeVars
+      # without PEP 696 defaults, so bare `np.ndarray` trips disallow_any_generics.
+      # Run mypy once on 3.13 (numpy 2.4.3, stubs with defaults); runtime
+      # behaviour on older Pythons is covered by the test step below.
       - name: Type check
+        if: matrix.python-version == '3.13'
         run: uv run mypy
 
       - name: Test


### PR DESCRIPTION
## Problem

CI's `check` job runs `uv run mypy` inside every matrix Python env. On the **3.10** leg, uv resolves **numpy 2.2.6**, whose `ndarray` TypeVars (`_ShapeT_co`, `_DTypeT_co`) lack PEP 696 `default=` declarations. Under `strict` mypy that makes bare `np.ndarray` annotations trip `disallow_any_generics`, producing ~470 `[type-arg]` errors and failing the leg (which fail-fast-cancels 3.11/3.12/3.13).

numpy **2.4.3** (resolved for py>=3.11) added the defaults, so those legs pass.

## Fix

Run the `Type check` step only on the 3.13 leg. This matches the existing `[tool.mypy]` config, which already pins `python_version = "3.13"` and documents that mypy runs on the highest supported Python while per-version runtime behaviour is covered by the test suite across the full matrix. Lint and tests still run on all four Python versions.

## Context

Follow-up to #16 (merged), which fixed the separate `FormulaMaterializerNotFoundError` failures in the `cholmod` and `pandas-free` jobs. Together these two changes get CI green again.

🤖 This pull request was assisted or created by Claude Code